### PR TITLE
Add customized log output

### DIFF
--- a/src/dk/legevognen/LogUtilities.groovy
+++ b/src/dk/legevognen/LogUtilities.groovy
@@ -1,0 +1,28 @@
+package dk.legevognen
+
+class LogUtilities {
+
+    def script
+
+    LogUtilities(pipelineScript) {
+        script = pipelineScript
+    }
+    
+    void info(String message="") {
+        script.echo("[\u001B[1;34mINFO\u001B[0m] ${message}")
+    }
+
+    void warning(String message="") {
+        script.echo("[\u001B[1;33mWARNING\u001B[0m] ${message}")
+    }
+
+    void severe(String message="") {
+        script.echo("[\u001B[1;31mSEVERE\u001B[0m] ${message}")
+    }
+
+    void debug(String message="") {
+        if(script.env.JENKINSFILE_DEBUG) {
+            script.echo("[\u001B[1;32mDEBUG\u001B[0m] ${message}")
+        }
+    }
+}

--- a/vars/logOut.groovy
+++ b/vars/logOut.groovy
@@ -1,0 +1,19 @@
+import dk.legevognen.LogUtilities
+
+void call(String level='INFO', String message="") {
+    LogUtilities logUtilities = new LogUtilities(this)
+
+    switch(level.toUpperCase()) {
+        case 'SEVERE':
+            logUtilities.severe(message)
+            break
+        case 'WARNING':
+            logUtilities.warning(message)
+            break
+        case 'DEBUG':
+            logUtilities.debug(message)
+            break
+        default:
+            logUtilities.info(message)
+    }
+}


### PR DESCRIPTION
#1 Add Groovy script

Add the ability to write to the job log output.

To allow for debug output to be shown, add this to the top of the Jenkinsfile `env.JENKINSFILE_DEBUG = true`

Example usage:
```
... [groovy code]
logOut('DEBUG', "statusCode: $statusCode")
... [groovy code]
```
Valid logging levels are:
INFO, WARNING, SEVERE, or DEBUG.